### PR TITLE
Add support for RFC6960's id-pkix-ocsp-extended-revoke

### DIFF
--- a/src/libpki/pki_time.h
+++ b/src/libpki/pki_time.h
@@ -8,6 +8,7 @@ PKI_TIME *PKI_TIME_new( long long offset );
 void PKI_TIME_free_void( void *time );
 int PKI_TIME_free( PKI_TIME *time );
 
+PKI_TIME *PKI_TIME_set(PKI_TIME *time, time_t new_time);
 int PKI_TIME_adj( PKI_TIME *time, long long offset );
 
 PKI_TIME * PKI_TIME_dup ( PKI_TIME *time );

--- a/src/openssl/pki_ocsp_resp.c
+++ b/src/openssl/pki_ocsp_resp.c
@@ -204,6 +204,14 @@ int PKI_X509_OCSP_RESP_add ( PKI_X509_OCSP_RESP *resp,
 		}
 	}
 
+	//We specify NID_id_pkix_OCSP_valid due to an error in OpenSSL's code, see http://marc.info/?l=openssl-users&m=138573884214852&w=2
+	if (!OCSP_SINGLERESP_add1_ext_i2d(single,
+				NID_id_pkix_OCSP_valid, "", 0 ,0))
+	{
+		PKI_log_err("Can not create \"extended revoke\" extension entry for response!");
+		return PKI_ERR;
+	}
+
 	return PKI_OK;
 }
 

--- a/src/openssl/pki_ocsp_resp.c
+++ b/src/openssl/pki_ocsp_resp.c
@@ -159,7 +159,7 @@ int PKI_X509_OCSP_RESP_add ( PKI_X509_OCSP_RESP *resp,
 
 	OCSP_SINGLERESP *single = NULL;
 	PKI_TIME *myThisUpdate = NULL;
-
+	X509_EXTENSION *extendedRevocation = NULL;
 	PKI_OCSP_RESP *r = NULL;
 
 	if ( !resp || !resp->value || !cid ) return ( PKI_ERR );
@@ -204,11 +204,22 @@ int PKI_X509_OCSP_RESP_add ( PKI_X509_OCSP_RESP *resp,
 		}
 	}
 
+	if ((extendedRevocation = X509_EXTENSION_new()) == NULL)
+	{
+		PKI_log_err("Can't allocate memory for extended revocation extension.");
+		//ERR_print_errors_fp(stdout);
+		return PKI_ERR;
+	}
+	//As per RFC6960 set critical to 0 and the OID to id-pkix-ocsp-extended-revoke and value to NULL
 	//We specify NID_id_pkix_OCSP_valid due to an error in OpenSSL's code, see http://marc.info/?l=openssl-users&m=138573884214852&w=2
-	if (!OCSP_SINGLERESP_add1_ext_i2d(single,
-				NID_id_pkix_OCSP_valid, "", 0 ,0))
+	extendedRevocation->critical = 0;
+	extendedRevocation->object = OBJ_nid2obj(NID_id_pkix_OCSP_valid);
+	extendedRevocation->value = ASN1_OCTET_STRING_new();
+	//This extension goes to responseExtensions and not singleExtensions like invalidityDate
+	if (!OCSP_BASICRESP_add_ext(r->bs, extendedRevocation, -1))
 	{
 		PKI_log_err("Can not create \"id-pkix-ocsp-extended-revoke\" extension entry for response!");
+		//ERR_print_errors_fp(stdout);
 		return PKI_ERR;
 	}
 

--- a/src/openssl/pki_ocsp_resp.c
+++ b/src/openssl/pki_ocsp_resp.c
@@ -208,7 +208,7 @@ int PKI_X509_OCSP_RESP_add ( PKI_X509_OCSP_RESP *resp,
 	if (!OCSP_SINGLERESP_add1_ext_i2d(single,
 				NID_id_pkix_OCSP_valid, "", 0 ,0))
 	{
-		PKI_log_err("Can not create \"extended revoke\" extension entry for response!");
+		PKI_log_err("Can not create \"id-pkix-ocsp-extended-revoke\" extension entry for response!");
 		return PKI_ERR;
 	}
 

--- a/src/openssl/pki_time.c
+++ b/src/openssl/pki_time.c
@@ -50,6 +50,19 @@ int PKI_TIME_free( PKI_TIME *time ) {
 }
 
 /*!
+ * \brief Sets the passed PKI_TIME to the provided time_t
+ */
+
+PKI_TIME *PKI_TIME_set(PKI_TIME *time, time_t new_time) {
+
+	if (!time) {
+		return NULL;
+	}
+
+	return ASN1_GENERALIZEDTIME_adj(time, new_time, 0, 0);
+}
+
+/*!
  * \brief Adjusts the time by adding/subtracting the offset seconds from current value
  */
 


### PR DESCRIPTION
This patch adds an extension to the basic response created that specifies that our OCSP responder knows of the RFC6960 new Extended Revocation status. For this reason we also supply a new libPKI API call, PKI_TIME_set, so the OCSP responder can set the revocation time to "1 January 1970".

https://tools.ietf.org/html/rfc6960#section-2.2