### PR TITLE
Fix build on Mac OS X with OpenSSL 1.0.2d from Homebrew.

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -115,7 +115,7 @@ if [[ "$library_setup" = "no" ]] ; then
 
 
 		AC_MSG_RESULT([Searching OpenSSL Version: $library_includes]);
-		ver=`grep "#define SHLIB_VERSION_NUMBER" $library_includes | sed 's/[#_a-zA-Z" ]//g' | sed 's|\.|0|g'`;
+		ver=`grep "^ *# *define  *SHLIB_VERSION_NUMBER" $library_includes | sed 's/[#_a-zA-Z" ]//g' | sed 's|\.|0|g'`;
 		my_ver=`echo $_version | sed "s|\.|0|g"`;
 
 		AC_MSG_RESULT([Detected Version: $ver (required > $my_ver )]);


### PR DESCRIPTION
The opensslv.h header has a space after preprocessor directives. This change makes the regular expression that looks for the shared library version number less strict, whilst still conforming to C preprocessor syntax.