### PR TITLE
Update configure.ac to add amd64 arch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,10 @@ case "$my_arch" in
     mybits="64"
     mybits_install="64"
     ;;
+  *amd64)
+    mybits="64"
+    mybits_install="64"
+    ;;
   *sparc*)
     mybits="64"
     mybits_install="64"


### PR DESCRIPTION
Add "amd64" architecture as detected in FreeBSD
Otherwise configure fails with error:
"configure: error: Not supported arch (amd64)"