### PR TITLE
Changed to be compatible with OpenSSL v1.1.1

### DIFF
--- a/src/pki_x509.c
+++ b/src/pki_x509.c
@@ -526,7 +526,7 @@ PKI_MEM * PKI_X509_VALUE_get_tbs_asn1(const void         * v,
                                                &(mem->data),
                                                ta->it);
 #else
-	mem->size = (size_t) ASN1_item_i2d((void *)&ta->data,
+	mem->size = (size_t) ASN1_item_i2d((void *)ta->data,
                                                &(mem->data),
                                                ta->it);
 #endif


### PR DESCRIPTION
test1.c passed successfully.
Old codes were not removed for future use.