### PR TITLE
Bugfixes

### DIFF
--- a/src/drivers/pkcs11/pkcs11_hsm_pkey.c
+++ b/src/drivers/pkcs11/pkcs11_hsm_pkey.c
@@ -46,11 +46,13 @@ static CK_MECHANISM RSA_MECH_LIST[RSA_MECH_LIST_SIZE] = {
 	{CKM_RSA_PKCS_KEY_PAIR_GEN, NULL_PTR, 0 }
 };
 
+#ifdef ENABLE_ECDSA
 // Definitions for the ECDSA Key Generation Mechs
 #define EC_MECH_LIST_SIZE 1
 static CK_MECHANISM EC_MECH_LIST[EC_MECH_LIST_SIZE] = {
 	{CKM_EC_KEY_PAIR_GEN, NULL_PTR, 0}
 };
+#endif
 
 #ifdef __DISABLED__
 // Currently Disabled
@@ -928,7 +930,7 @@ const RSA_METHOD * HSM_PKCS11_get_rsa_method ( void ) {
 const EC_KEY_METHOD * HSM_PKCS11_get_ecdsa_method ( void ) {
 
 	static EC_KEY_METHOD * r_pnt = NULL;
-
+#ifdef ENABLE_ECDSA
 	if (!r_pnt) {
 
 #if OPENSSL_VERSION_NUMBER < 0x1010000fL
@@ -979,7 +981,7 @@ const EC_KEY_METHOD * HSM_PKCS11_get_ecdsa_method ( void ) {
 			                   );
 #endif
 	}
-
+#endif
 	return r_pnt;
 
 }

--- a/src/libpki/hsm_st.h
+++ b/src/libpki/hsm_st.h
@@ -2,6 +2,9 @@
 #ifndef _LIBPKI_HSM_ST_H
 #define _LIBPKI_HSM_ST_H
 
+#include <libpki/net/url.h>
+#include <libpki/pki_x509_data_st.h>
+
 #define MANUFACTURER_ID_SIZE   32
 #define DESCRIPTION_SIZE       32
 #define SLOT_DESCRIPTION_SIZE  64
@@ -161,36 +164,36 @@ typedef struct hsm_slot_info_st {
 
 /* Forward Declarations */
 struct hsm_st;
-typedef struct hsm_st HSM;
+// typedef struct hsm_st HSM;
 
 struct pki_mem_st;
-typedef struct pki_mem_st PKI_MEM;
+// typedef struct pki_mem_st PKI_MEM;
 
 #ifndef _LIBPKI_PKI_X509_DATA_ST_H
 
   /* Forward Declaration for PKI_X509 structure */
   struct pki_x509_st;
-  typedef struct pki_x509_st PKI_X509;
+//  typedef struct pki_x509_st PKI_X509;
 
   /* Forward Definition for PKI_X509_CERT */
   #define PKI_X509_CERT PKI_X509
 
   /* Forward Declaration of URL structure */
   struct url_data_st;
-  typedef struct url_data_st URL;
+//  typedef struct url_data_st URL;
 
   /* Forward Declaration of PKI_STACK and PKI_X509_STACK */
   struct pki_stack_st;
-  typedef struct pki_stack_st PKI_STACK;
-  typedef PKI_STACK PKI_X509_STACK;
+//  typedef struct pki_stack_st PKI_STACK;
+//  typedef PKI_STACK PKI_X509_STACK;
 
   /* Forward Declaration of PKI_X509_CALLBACKS structure */
   struct pki_x509_callbacks_st;
-  typedef struct pki_x509_callbacks_st PKI_X509_CALLBACKS;
+//  typedef struct pki_x509_callbacks_st PKI_X509_CALLBACKS;
 
   /* Forward Declaration of PKI_X509_PROFILE structure */
   struct xmlDoc;
-  typedef struct xmlDoc PKI_X509_PROFILE;
+//  typedef struct xmlDoc PKI_X509_PROFILE;
 
 #endif
 

--- a/src/libpki/net/pki_mysql.h
+++ b/src/libpki/net/pki_mysql.h
@@ -7,18 +7,18 @@
 
 #include <mysql.h>
 
-MYSQL *db_connect ( URL *url );
+MYSQL *db_connect ( const URL *url );
 int db_close ( MYSQL *sql );
 
 #endif /* HAVE_MYSQL */
 
-char *parse_url_table ( URL * url );
-char *parse_url_dbname ( URL *url );
+char *parse_url_table ( const URL * url );
+char *parse_url_dbname ( const URL *url );
 
-PKI_MEM_STACK *URL_get_data_mysql ( char *url_s, ssize_t size );
-PKI_MEM_STACK *URL_get_data_mysql_url ( URL *url, ssize_t size );
+PKI_MEM_STACK *URL_get_data_mysql ( const char *url_s, ssize_t size );
+PKI_MEM_STACK *URL_get_data_mysql_url ( const URL *url, ssize_t size );
 
-int URL_put_data_mysql ( char *url_s, PKI_MEM *data );
-int URL_put_data_mysql_url ( URL *url, PKI_MEM *data );
+int URL_put_data_mysql ( const char *url_s, const PKI_MEM *data );
+int URL_put_data_mysql_url ( const URL *url, const PKI_MEM *data );
 
 #endif /* _LIBPKI_URL_MYSQL_H */

--- a/src/libpki/net/pki_pg.h
+++ b/src/libpki/net/pki_pg.h
@@ -7,18 +7,18 @@
 
 #include <libpq-fe.h>
 
-PGconn *pg_db_connect ( URL *url );
+PGconn *pg_db_connect ( const URL *url );
 int pg_db_close ( PGconn *sql );
 
 #endif /* HAVE_PG */
 
-char *pg_parse_url_table ( URL * url );
-char *pg_parse_url_dbname ( URL *url );
+char *pg_parse_url_table ( const URL * url );
+char *pg_parse_url_dbname ( const URL *url );
 
-PKI_MEM_STACK *URL_get_data_pg ( char *url_s, ssize_t size );
-PKI_MEM_STACK *URL_get_data_pg_url ( URL *url, ssize_t size );
+PKI_MEM_STACK *URL_get_data_pg ( const char *url_s, ssize_t size );
+PKI_MEM_STACK *URL_get_data_pg_url ( const URL *url, ssize_t size );
 
-int URL_put_data_pg ( char *url_s, PKI_MEM *data );
-int URL_put_data_pg_url ( URL *url, PKI_MEM *data );
+int URL_put_data_pg ( const char *url_s, const PKI_MEM *data );
+int URL_put_data_pg_url ( const URL *url, const PKI_MEM *data );
 
 #endif /* _LIBPKI_URL_PG_H */

--- a/src/libpki/net/ssl.h
+++ b/src/libpki/net/ssl.h
@@ -18,6 +18,7 @@
 #define _LIBPKI_PKI_SSL_H
 
 #include <openssl/ssl.h>
+#include <libpki/pki_x509_data_st.h>
 
 /*! \brief Algorithms for PKI_SSL connections */
 typedef SSL_METHOD PKI_SSL_ALGOR;
@@ -273,7 +274,7 @@ typedef struct  pki_ssl_t {
 
   /* Forward Declaration for PKI_X509 structure */
   struct pki_x509_st;
-  typedef struct pki_x509_st PKI_X509;
+//  typedef struct pki_x509_st PKI_X509;
 
   /* Forward Definition for PKI_X509_CERT */
 #define PKI_X509_CERT PKI_X509

--- a/src/libpki/openssl/data_st.h
+++ b/src/libpki/openssl/data_st.h
@@ -460,7 +460,6 @@ typedef struct pki_x509_extension_st {
 
 #define PKI_X509_EXTENSION_VALUE	X509_EXTENSION
 
-#ifdef ENABLE_ECDSA
 typedef enum {
 	PKI_EC_KEY_FORM_UNKNOWN		=	0,
 	PKI_EC_KEY_FORM_COMPRESSED	=	POINT_CONVERSION_COMPRESSED,
@@ -478,7 +477,6 @@ typedef enum {
 
 #define PKI_EC_KEY_ASN1_DEFAULT			PKI_EC_KEY_ASN1_NAMED_CURVE
 
-#endif // ENABLE_ECDSA
 
 typedef struct pki_keyparams_st {
 	int bits;

--- a/src/net/mysql.c
+++ b/src/net/mysql.c
@@ -8,7 +8,7 @@
  
 #include <libpki/pki.h>
 
-char *parse_url_query ( URL * url ) {
+char *parse_url_query ( const URL * url ) {
 
 	char * ret = NULL;
 	char * table = NULL;
@@ -99,7 +99,7 @@ char *parse_url_query ( URL * url ) {
 	return( ret );
 }
 
-char *parse_url_put_query ( URL * url, PKI_MEM *data ) {
+char *parse_url_put_query ( const URL * url, const PKI_MEM *data ) {
 
 	char * ret = NULL;
 	char * table = NULL;
@@ -209,7 +209,7 @@ char *parse_url_put_query ( URL * url, PKI_MEM *data ) {
 	return( ret );
 }
 
-char *parse_url_table ( URL * url ) {
+char *parse_url_table ( const URL * url ) {
 	char *tmp_s = NULL;
 	char *tmp_s2 = NULL;
 	char *ret = NULL;
@@ -242,7 +242,7 @@ char *parse_url_table ( URL * url ) {
 	return( ret );
 }
 
-char *parse_url_dbname ( URL *url ) {
+char *parse_url_dbname ( const URL *url ) {
 
 	char *tmp_s = NULL;
 	char *ret = NULL;
@@ -267,7 +267,7 @@ char *parse_url_dbname ( URL *url ) {
 
 #ifdef HAVE_MYSQL
 
-MYSQL *db_connect ( URL *url ) {
+MYSQL *db_connect ( const URL *url ) {
 
 	MYSQL *sql = NULL;
 	char * table = NULL;
@@ -308,7 +308,7 @@ int db_close ( MYSQL *sql ) {
 
 #endif
 
-PKI_MEM_STACK *URL_get_data_mysql ( char *url_s, ssize_t size )
+PKI_MEM_STACK *URL_get_data_mysql ( const char *url_s, ssize_t size )
 {
 	PKI_MEM_STACK *ret = NULL;
 	URL *url = NULL;
@@ -343,7 +343,7 @@ PKI_MEM_STACK *URL_get_data_mysql ( char *url_s, ssize_t size )
 	return ret;
 }
 
-PKI_MEM_STACK *URL_get_data_mysql_url ( URL *url, ssize_t size ) {
+PKI_MEM_STACK *URL_get_data_mysql_url ( const URL *url, ssize_t size ) {
 
 #ifdef HAVE_MYSQL
 	MYSQL_ROW row;
@@ -426,7 +426,7 @@ end:
 #endif
 }
 
-int URL_put_data_mysql ( char *url_s, PKI_MEM *data ) {
+int URL_put_data_mysql ( const char *url_s, const PKI_MEM *data ) {
 
 	int ret = 0;
 	URL *url = NULL;
@@ -463,7 +463,7 @@ int URL_put_data_mysql ( char *url_s, PKI_MEM *data ) {
 	return ret;
 }
 
-int URL_put_data_mysql_url ( URL *url, PKI_MEM *data ) {
+int URL_put_data_mysql_url ( const URL *url, const PKI_MEM *data ) {
 
 #ifdef HAVE_MYSQL
 	MYSQL * sql = NULL;

--- a/src/net/pg.c
+++ b/src/net/pg.c
@@ -8,7 +8,7 @@
  
 #include <libpki/pki.h>
 
-char *pg_parse_url_query ( URL * url ) {
+char *pg_parse_url_query ( const URL * url ) {
 
 	char * ret = NULL;
 	char * table = NULL;
@@ -79,7 +79,7 @@ char *pg_parse_url_query ( URL * url ) {
 	return( ret );
 }
 
-char *pg_parse_url_put_query ( URL * url, PKI_MEM *data ) {
+char *pg_parse_url_put_query ( const URL * url, const PKI_MEM *data ) {
 
 	char * ret = NULL;
 	char * table = NULL;
@@ -190,7 +190,7 @@ char *pg_parse_url_put_query ( URL * url, PKI_MEM *data ) {
 }
 
 
-char *pg_parse_url_table ( URL * url ) {
+char *pg_parse_url_table ( const URL * url ) {
 	char *tmp_s = NULL;
 	char *tmp_s2 = NULL;
 	char *ret = NULL;
@@ -223,7 +223,7 @@ char *pg_parse_url_table ( URL * url ) {
 	return( ret );
 }
 
-char *pg_parse_url_dbname ( URL *url ) {
+char *pg_parse_url_dbname ( const URL *url ) {
 
 	char *tmp_s = NULL;
 	char *ret = NULL;
@@ -248,7 +248,7 @@ char *pg_parse_url_dbname ( URL *url ) {
 
 #ifdef HAVE_PG
 
-PGconn *pg_db_connect ( URL *url ) {
+PGconn *pg_db_connect ( const URL *url ) {
 
         PGconn *sql = NULL;
 	char * dbname = NULL;
@@ -280,7 +280,7 @@ int pg_db_close ( PGconn *sql ) {
 
 #endif
 
-PKI_MEM_STACK *URL_get_data_pg ( char *url_s, ssize_t size ) {
+PKI_MEM_STACK *URL_get_data_pg ( const char *url_s, ssize_t size ) {
 	URL *url = NULL;
 
 	if( !url_s ) return (NULL);
@@ -293,7 +293,7 @@ PKI_MEM_STACK *URL_get_data_pg ( char *url_s, ssize_t size ) {
 	return ( URL_get_data_pg_url( url, size ));
 }
 
-PKI_MEM_STACK *URL_get_data_pg_url ( URL *url, ssize_t size ) {
+PKI_MEM_STACK *URL_get_data_pg_url ( const URL *url, ssize_t size ) {
 
 #ifdef HAVE_PG
 	PGconn *sql;
@@ -368,7 +368,7 @@ PKI_MEM_STACK *URL_get_data_pg_url ( URL *url, ssize_t size ) {
 #endif
 }
 
-int URL_put_data_pg ( char *url_s, PKI_MEM *data ) {
+int URL_put_data_pg ( const char *url_s, const PKI_MEM *data ) {
 
 	URL *url = NULL;
 	int ret = 0;
@@ -386,7 +386,7 @@ int URL_put_data_pg ( char *url_s, PKI_MEM *data ) {
 	return ( ret );
 }
 
-int URL_put_data_pg_url ( URL *url, PKI_MEM *data ) {
+int URL_put_data_pg_url ( const URL *url, const PKI_MEM *data ) {
 
 #ifdef HAVE_PG
 	PGconn * sql = NULL;

--- a/src/openssl/pki_keyparams.c
+++ b/src/openssl/pki_keyparams.c
@@ -193,6 +193,7 @@ int PKI_KEYPARAMS_set_curve(PKI_KEYPARAMS   * kp,
                             PKI_EC_KEY_FORM   curveForm,
                             PKI_EC_KEY_ASN1   asn1flags) {
 
+#ifdef ENABLE_ECDSA
 	int curveId = 0;
 
 	// Input Checks
@@ -214,6 +215,9 @@ int PKI_KEYPARAMS_set_curve(PKI_KEYPARAMS   * kp,
 
 	// All Done
 	return PKI_OK;
+#else
+	return PKI_ERR;
+#endif
 };
 
 /*! \brief Sets the bits size for key generation */

--- a/src/pki_x509.c
+++ b/src/pki_x509.c
@@ -521,15 +521,10 @@ PKI_MEM * PKI_X509_VALUE_get_tbs_asn1(const void         * v,
 		return NULL;
 	}
 
-#if OPENSSL_VERSION_NUMBER > 0x1010000fL
+	// distinction between openssl versions is done inside __datatype_get_asn1_ref 
 	mem->size = (size_t) ASN1_item_i2d((void *)ta->data,
                                                &(mem->data),
                                                ta->it);
-#else
-	mem->size = (size_t) ASN1_item_i2d((void *)&ta->data,
-                                               &(mem->data),
-                                               ta->it);
-#endif
 
 	 // Free the TA Data
 	 PKI_Free(ta);


### PR DESCRIPTION
here a couple of bugfixes for libpki 0.9.0

-   make url a const in mysql interface
-   make url a const in pg interface
-    fix compile errors when ecdsa is disabled
-    avoid duplicate forward declarations of structures (this is not really a bug to fix but this change makes the code backwards compatible to RHEL 6 with gcc 4.4.7)

