### PR TITLE
Fix compile error in 0.9.0

### DIFF
--- a/src/pki_config.c
+++ b/src/pki_config.c
@@ -83,7 +83,7 @@ static char * _xml_search_namespace_add ( char *search ) {
 	PKI_Free( my_arg );
 
 	ret = PKI_Malloc ( strlen( my_search ) + 1);
-	strncpy( ret, my_search, strlen(my_search) );
+	strcpy( ret, my_search );
 
 	PKI_Free ( my_search );
 	return( ret );


### PR DESCRIPTION
libpki 0.9.0 will not compile on CentOS 8. It fails with an error on line 86 of src/pki_config.c:

 error: 'strncpy' specified bound depends on the length of the source argument.

Since the destination buffer, ret, is allocated a buffer of size strlen(my_search)+1, there doesn't seem to be a reason to use strncpy rather than strcpy.