### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -267,6 +267,7 @@ case "${build_os}" in
 		;;
  *bsd*) myarch=bsd
 		shlext=so
+		mybits_install=""
 		;;
  *iphone*)
 		myarch=iphone
@@ -306,6 +307,9 @@ case "$target" in
 		arch_target=x86
 		;;
 	x86_64-*)
+		arch_target=x86_64
+		;;
+	amd64*-*)
 		arch_target=x86_64
 		;;
 	sparc*-*)

--- a/src/libpki/pki.h
+++ b/src/libpki/pki.h
@@ -31,6 +31,8 @@ extern const long LIBPKI_OS_DETAILS;
 #include <ctype.h>
 #include <sys/types.h>
 
+#include <sys/socket.h>
+
 #define __XOPEN_OR_POSIX
 #include <signal.h>
 #undef __XOPEN_OR_POSIX


### PR DESCRIPTION
Small fixes in configure.ac 
- overriding mybits_install=64 in *bsd* as there is no lib64 in FreeBSD
- adding a amd64 target mapped to x86_64 as FreeBSD detects it this way
And in src/libpki/pki.h
- adding sys/socket.h to includes list as it is needed to compile on FreeBSD