### PR TITLE
78 port libpki to openssl 3x

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -115,13 +115,20 @@ if [[ "$library_setup" = "no" ]] ; then
 
 
 		AC_MSG_RESULT([Searching OpenSSL Version: $library_includes]);
-		ver=`grep "^ *# *define  *OPENSSL_VERSION_NUMBER" "$library_includes" | sed 's/.*0x/0x/g' | sed 's|\L||g'`;
+
+		# Try the OpenSSL 0.9 ... 1.1.1+ format first
+		ver=`grep "^ *# *define  *OPENSSL_VERSION_NUMBER" "$library_includes" | sed 's/.*0x/0x/g' | sed 's|.*\\||g' | sed 's|\L||g'`;
 		if [[ "x$ver" == "x" ]] ; then
-		   pver=`grep "^ *# *define OPENSSL_VERSION_PRE_RELEASE" "$library_includes" | sed 's|.* "|"|g' | sed 's|""|fL|g' | sed 's|".*"|0L|g'`
-		   bver=`grep "^ *# *define OPENSSL_VERSION_STR" "$library_includes"  | sed 's|.* "||g' | sed 's|".*||g' | sed 's|\.| |g' | xargs printf "0x%1x%02X%02X" `
-		   ver="$bver$pver"
+			# checks the OpenSSL 3+ format second
+			ossl_major=`grep "define OPENSSL_VERSION_MAJOR" "$library_includes" | sed 's|.*OPENSSL_VERSION_MAJOR[ ]*||g'`
+			ossl_minor=`grep "define OPENSSL_VERSION_MINOR" "$library_includes" | sed 's|.*OPENSSL_VERSION_MINOR[ ]*||g'`
+			ossl_patch=`grep "define OPENSSL_VERSION_PATCH" "$library_includes" | sed 's|.*OPENSSL_VERSION_PATCH[ ]*||g'`
+			ver=`printf "0x%d%2.2d%2.2d00f" $ossl_major $ossl_minor $ossl_patch`
+			# pver=`grep "^ *# *define OPENSSL_VERSION_PRE_RELEASE" "$library_includes" | sed 's|.* "|"|g' | sed 's|""|fL|g' | sed 's|".*"|0L|g'`
+			# bver=`grep "^ *# *define OPENSSL_VERSION_STR" "$library_includes"  | sed 's|.* "||g' | sed 's|".*||g' | sed 's|\.| |g' | xargs printf "0x%1x%02X%02X" `
+			# ver="$bver$pver"
 		fi
-                detected_v=`echo $((ver))`
+    	detected_v=`echo $((ver))`
 		required_v=`echo $(($_version))`
 
 		dnl ver=`grep "^ *# *define  *SHLIB_VERSION_NUMBER" $library_includes | sed 's/[#_a-zA-Z" ]//g' | sed 's|\.|0|g'`;
@@ -314,11 +321,13 @@ if [[ $ok = 0 ]] ; then
 	library_libs=
 	library_setup=no
 else
-	AC_MSG_RESULT([Library OPENSSL prefix... $library_prefix ])
-	AC_MSG_RESULT([Library OPENSSL is SHARED... $library_shared ])
-	AC_MSG_RESULT([Library OPENSSL C flags... $library_cflags ])
-	AC_MSG_RESULT([Library OPENSSL LD flags... $library_ldflags ])
-	AC_MSG_RESULT([Library OPENSSL LIBS flags ... $library_libs ])
+	AC_MSG_RESULT([ Library OPENSSL prefix... $library_prefix ])
+	AC_MSG_RESULT([ Library OPENSSL is SHARED... $library_shared ])
+	AC_MSG_RESULT([ Library OPENSSL C flags... $library_cflags ])
+	AC_MSG_RESULT([ Library OPENSSL LD flags... $library_ldflags ])
+	AC_MSG_RESULT([ Library OPENSSL LIBS flags ... $library_libs ])
+	AC_MSG_RESULT([ Library OPENSSL required version ... $_version ])
+	AC_MSG_RESULT([ Library OPENSSL detected version... $ver ])
 	library_setup=yes
 fi
 

--- a/configure
+++ b/configure
@@ -18033,13 +18033,20 @@ printf "%s\n" "OpenSSL Checking Path: ${library_includes} does not exists!" >&6;
 
 		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Searching OpenSSL Version: $library_includes" >&5
 printf "%s\n" "Searching OpenSSL Version: $library_includes" >&6; };
-		ver=`grep "^ *# *define  *OPENSSL_VERSION_NUMBER" "$library_includes" | sed 's/.*0x/0x/g' | sed 's|\L||g'`;
+
+		# Try the OpenSSL 0.9 ... 1.1.1+ format first
+		ver=`grep "^ *# *define  *OPENSSL_VERSION_NUMBER" "$library_includes" | sed 's/.*0x/0x/g' | sed 's|.*\\||g' | sed 's|\L||g'`;
 		if [ "x$ver" == "x" ] ; then
-		   pver=`grep "^ *# *define OPENSSL_VERSION_PRE_RELEASE" "$library_includes" | sed 's|.* "|"|g' | sed 's|""|fL|g' | sed 's|".*"|0L|g'`
-		   bver=`grep "^ *# *define OPENSSL_VERSION_STR" "$library_includes"  | sed 's|.* "||g' | sed 's|".*||g' | sed 's|\.| |g' | xargs printf "0x%1x%02X%02X" `
-		   ver="$bver$pver"
+			# checks the OpenSSL 3+ format second
+			ossl_major=`grep "define OPENSSL_VERSION_MAJOR" "$library_includes" | sed 's|.*OPENSSL_VERSION_MAJOR *||g'`
+			ossl_minor=`grep "define OPENSSL_VERSION_MINOR" "$library_includes" | sed 's|.*OPENSSL_VERSION_MINOR *||g'`
+			ossl_patch=`grep "define OPENSSL_VERSION_PATCH" "$library_includes" | sed 's|.*OPENSSL_VERSION_PATCH *||g'`
+			ver=`printf "0x%d%2.2d%2.2d00f" $ossl_major $ossl_minor $ossl_patch`
+			# pver=`grep "^ *# *define OPENSSL_VERSION_PRE_RELEASE" "$library_includes" | sed 's|.* "|"|g' | sed 's|""|fL|g' | sed 's|".*"|0L|g'`
+			# bver=`grep "^ *# *define OPENSSL_VERSION_STR" "$library_includes"  | sed 's|.* "||g' | sed 's|".*||g' | sed 's|\.| |g' | xargs printf "0x%1x%02X%02X" `
+			# ver="$bver$pver"
 		fi
-                detected_v=`echo $((ver))`
+    	detected_v=`echo $((ver))`
 		required_v=`echo $(($_version))`
 
 
@@ -18165,16 +18172,20 @@ if [ $ok = 0 ] ; then
 	library_libs=
 	library_setup=no
 else
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Library OPENSSL prefix... $library_prefix " >&5
-printf "%s\n" "Library OPENSSL prefix... $library_prefix " >&6; }
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Library OPENSSL is SHARED... $library_shared " >&5
-printf "%s\n" "Library OPENSSL is SHARED... $library_shared " >&6; }
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Library OPENSSL C flags... $library_cflags " >&5
-printf "%s\n" "Library OPENSSL C flags... $library_cflags " >&6; }
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Library OPENSSL LD flags... $library_ldflags " >&5
-printf "%s\n" "Library OPENSSL LD flags... $library_ldflags " >&6; }
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Library OPENSSL LIBS flags ... $library_libs " >&5
-printf "%s\n" "Library OPENSSL LIBS flags ... $library_libs " >&6; }
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result:  Library OPENSSL prefix... $library_prefix " >&5
+printf "%s\n" " Library OPENSSL prefix... $library_prefix " >&6; }
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result:  Library OPENSSL is SHARED... $library_shared " >&5
+printf "%s\n" " Library OPENSSL is SHARED... $library_shared " >&6; }
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result:  Library OPENSSL C flags... $library_cflags " >&5
+printf "%s\n" " Library OPENSSL C flags... $library_cflags " >&6; }
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result:  Library OPENSSL LD flags... $library_ldflags " >&5
+printf "%s\n" " Library OPENSSL LD flags... $library_ldflags " >&6; }
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result:  Library OPENSSL LIBS flags ... $library_libs " >&5
+printf "%s\n" " Library OPENSSL LIBS flags ... $library_libs " >&6; }
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result:  Library OPENSSL required version ... $_version " >&5
+printf "%s\n" " Library OPENSSL required version ... $_version " >&6; }
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result:  Library OPENSSL detected version... $ver " >&5
+printf "%s\n" " Library OPENSSL detected version... $ver " >&6; }
 	library_setup=yes
 fi
 
@@ -18441,7 +18452,7 @@ oqs_prefix=/usr
 oqs_ldflags=
 oqs_ldadd=
 
-cli_oqs=
+cli_oqs=no
 
 # Check whether --enable-oqs was given.
 if test ${enable_oqs+y}
@@ -18453,9 +18464,9 @@ else $as_nop
 fi
 
 
-if ! [ "x$cli_oqs" = "xno" ] ; then
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: Open Quantum Safe: Enabled via CLI option" >&5
-printf "%s\n" "Open Quantum Safe: Enabled via CLI option" >&6; }
+if [ "x$cli_oqs" = "xyes" ] ; then
+	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result:  Open Quantum Safe: Enabled via CLI option ($cli_oqs) " >&5
+printf "%s\n" " Open Quantum Safe: Enabled via CLI option ($cli_oqs) " >&6; }
 
 printf "%s\n" "#define ENABLE_OQS 1" >>confdefs.h
 

--- a/configure.ac
+++ b/configure.ac
@@ -1504,7 +1504,7 @@ oqs_ldflags=
 oqs_ldadd=
 
 dnl Enable OQS support
-cli_oqs=
+cli_oqs=no
 
 AC_ARG_ENABLE(oqs,
 	[  --enable-oqs          enable oqs support (no)],
@@ -1512,9 +1512,9 @@ AC_ARG_ENABLE(oqs,
 	[cli_oqs=default]
  )
 
-if ! [[ "x$cli_oqs" = "xno" ]] ; then
-	AC_MSG_RESULT([Open Quantum Safe: Enabled via CLI option])
-	AC_DEFINE(ENABLE_OQS, 1, [Open Quantum Safe Support])
+if [[ "x$cli_oqs" = "xyes" ]] ; then
+	AC_MSG_RESULT([ Open Quantum Safe: Enabled via CLI option ($cli_oqs) ])
+	AC_DEFINE(ENABLE_OQS, 1, [ Open Quantum Safe Support ])
 	oqs_check="yes"
 	oqs_cflags="-DENABLE_OQS=1"
 	oqs_ldadd="-loqs"

--- a/src/drivers/openssl/openssl_hsm_pkey.c
+++ b/src/drivers/openssl/openssl_hsm_pkey.c
@@ -875,7 +875,9 @@ err:
     // Memory Cleanup
     if (value) EVP_PKEY_free(value);
     if (ret) PKI_X509_KEYPAIR_free(ret);
+#ifdef ENABLE_OQS
     if (ctx) EVP_PKEY_CTX_free(ctx);
+#endif
 
     // Error
     return NULL;
@@ -897,9 +899,13 @@ void HSM_OPENSSL_X509_KEYPAIR_free ( PKI_X509_KEYPAIR *pkey ) {
 // we have to provide our own function until OpenSSL solve
 // this issue
 
-int OPENSSL_HSM_write_bio_PrivateKey (BIO *bp, EVP_PKEY *x, 
-        const EVP_CIPHER *enc, unsigned char *out_buffer, int klen, 
-        pem_password_cb *cb, void *u) {
+int OPENSSL_HSM_write_bio_PrivateKey (BIO               * bp, 
+                                      EVP_PKEY          * x, 
+                                      const EVP_CIPHER  * enc, 
+                                      unsigned char     * out_buffer,
+                                      int                 klen, 
+                                      pem_password_cb   * cb,
+                                      void              * u) {
 
     int ret = PKI_ERR;
 
@@ -914,7 +920,7 @@ int OPENSSL_HSM_write_bio_PrivateKey (BIO *bp, EVP_PKEY *x,
         case EVP_PKEY_EC: {
 # if OPENSSL_VERSION_NUMBER >= 0x30000000L
             ret = PEM_write_bio_ECPrivateKey(bp, 
-                EVP_PKEY_get1_EC_KEY(x), enc, (unsigned char *) kstr, klen, cb, u);
+                EVP_PKEY_get1_EC_KEY(x), enc, (unsigned char *) out_buffer, klen, cb, u);
 # elif OPENSSL_VERSION_NUMBER < 0x1010000fL
             ret = PEM_write_bio_ECPrivateKey(bp, 
                 x->pkey.ec, enc, (unsigned char *) out_buffer, klen, cb, u);

--- a/src/libpki/datatypes.h
+++ b/src/libpki/datatypes.h
@@ -9,6 +9,9 @@
 #ifndef _LIBPKI_PKI_DATATYPES_H
 #define _LIBPKI_PKI_DATATYPES_H	
 
+// Include the library configuration
+#include <libpki/config.h>
+
 #ifndef _LIBPKI_COMPAT_H
 # include <libpki/compat.h>
 #endif

--- a/src/libpki/openssl/pki_oid_defs.h
+++ b/src/libpki/openssl/pki_oid_defs.h
@@ -6,8 +6,10 @@
 * Released under OpenCA LICENSE
 */
 
-#ifndef OQS_H
-#include <oqs/oqs.h>
+#ifdef ENABLE_OQS
+# ifndef OQS_H
+#  include <oqs/oqs.h>
+# endif
 #endif
 
 #ifndef _LIBPKI_OID_DEFS_H

--- a/src/libpki/openssl/pki_oid_defs.h
+++ b/src/libpki/openssl/pki_oid_defs.h
@@ -6,14 +6,17 @@
 * Released under OpenCA LICENSE
 */
 
+#ifndef _LIBPKI_OID_DEFS_H
+#define _LIBPKI_OID_DEFS_H
+
+// Include the library configuration
+#include <libpki/config.h>
+
 #ifdef ENABLE_OQS
 # ifndef OQS_H
 #  include <oqs/oqs.h>
 # endif
 #endif
-
-#ifndef _LIBPKI_OID_DEFS_H
-#define _LIBPKI_OID_DEFS_H
 
 // GENERAL
 # define LEVEL_OF_ASSURANCE_OID   		    "1.3.6.1.4.1.18227.50.1"

--- a/src/libpki/openssl/pqc/pqc_defs.h
+++ b/src/libpki/openssl/pqc/pqc_defs.h
@@ -6,12 +6,17 @@
 * Released under OpenCA LICENSE
 */
 
-#ifndef OQS_H
-#include <oqs/oqs.h>
-#endif
-
 #ifndef _LIBPKI_PQC_DEFS_H
 #define _LIBPKI_PQC_DEFS_H
+
+// Include the library configuration
+#include <libpki/config.h>
+
+#ifdef ENABLE_OQS
+# ifndef OQS_H
+#  include <oqs/oqs.h>
+# endif
+#endif
 
 // ===============
 // OQS definitions

--- a/src/openssl/composite/composite_ctx.c
+++ b/src/openssl/composite/composite_ctx.c
@@ -312,7 +312,7 @@ int COMPOSITE_CTX_explicit_algors_new0(COMPOSITE_CTX              * ctx,
                                        const COMPOSITE_KEY_STACK  * const components,
                                        X509_ALGORS               ** algors) {
 
-  int sk_num = 0;
+  int stack_elements_num = 0;
     // Number of elements in the stack
 
   X509_ALGORS * sk = NULL;
@@ -343,8 +343,8 @@ int COMPOSITE_CTX_explicit_algors_new0(COMPOSITE_CTX              * ctx,
   }
 
   // Gets the number of components
-  if ((sk_num = COMPOSITE_KEY_STACK_num(components)) < 2) {
-    PKI_DEBUG("Insufficient number of components in the key stack (%d)", sk_num);
+  if ((stack_elements_num = COMPOSITE_KEY_STACK_num(components)) < 2) {
+    PKI_DEBUG("Insufficient number of components in the key stack (%d)", stack_elements_num);
     return PKI_ERR;
   }
 
@@ -545,8 +545,8 @@ int COMPOSITE_CTX_explicit_algors_new0(COMPOSITE_CTX              * ctx,
     } break;
 
     case PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM5_FALCON1024_P521: {
-      if (sk_num != 3) {
-        PKI_DEBUG("Insufficient number of components in the key stack (%d)", sk_num);
+      if (stack_elements_num != 3) {
+        PKI_DEBUG("Insufficient number of components in the key stack (%d)", stack_elements_num);
         return PKI_ERR;
       }
       // Dilithium5 component
@@ -568,8 +568,8 @@ int COMPOSITE_CTX_explicit_algors_new0(COMPOSITE_CTX              * ctx,
     } break;
 
     case PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM5_FALCON1024_RSA: {
-      if (sk_num != 3) {
-        PKI_DEBUG("Insufficient number of components in the key stack (%d)", sk_num);
+      if (stack_elements_num != 3) {
+        PKI_DEBUG("Insufficient number of components in the key stack (%d)", stack_elements_num);
         return PKI_ERR;
       }
       // Dilithium5 component
@@ -596,8 +596,11 @@ int COMPOSITE_CTX_explicit_algors_new0(COMPOSITE_CTX              * ctx,
       return PKI_ERR;
   }
 
+  int algor_num = sk_X509_ALGOR_num(sk);
+  int components_num = COMPOSITE_KEY_STACK_num(components);
+  
   // Checks the number of components and algorithms to be the same
-  if (sk_X509_ALGOR_num(sk) != COMPOSITE_KEY_STACK_num(components)) {
+  if (algor_num != components_num) {
     PKI_DEBUG("Number of components (%d) and algorithms (%d) do not match",
               COMPOSITE_KEY_STACK_num(components), sk_X509_ALGOR_num(ctx->sig_algs));
     sk_X509_ALGOR_pop_free(sk, X509_ALGOR_free);

--- a/src/openssl/pki_algor.c
+++ b/src/openssl/pki_algor.c
@@ -1188,156 +1188,173 @@ PKI_SCHEME_ID PKI_SCHEME_ID_get_by_name(const char * data, int *classic_sec_bits
 		return PKI_SCHEME_UNKNOWN;
 	}
 
-#ifdef ENABLE_OQS
+#ifdef ENABLE_COMPOSITE
 
-	// Explicit Composite - DILITHIUM3-P256
-	if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_P256_SHA256_OID, 0, 1) == 0 ||
-		str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_P256_SHA256_NAME, 0, 1) == 0 ||
-		str_cmp_ex(data, "DILITHIUM3-ECDSA", 0, 1) == 0 ||
-		str_cmp_ex(data, "DILITHIUM3-EC", 0, 1) == 0 ||
-		str_cmp_ex(data, "DILITHIUM3-P256", 0, 1) == 0 ||
-		str_cmp_ex(data, "D3-P256", 0, 1) == 0 ||
-		str_cmp_ex(data, "DILITHIUM-P256", 0, 1) == 0) {
-		ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM3_P256;
-	// Explicit Composite - DILITHIUM3-RSA
-	} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_RSA_SHA256_OID, 0, 1) == 0 ||
-				str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_RSA_SHA256_NAME, 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM-RSA", 0, 1) == 0 ||
-				str_cmp_ex(data, "D3-RSA", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM3-RSA", 0, 1) == 0) {
-		ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM3_RSA;
-	// Explicit Composite - DILITHIUM3-BRAINPOOL256
-	} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_BRAINPOOL256_SHA256_OID, 0, 1) == 0 || 
-				str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_BRAINPOOL256_SHA256_NAME, 0, 1) == 0 || 
-				str_cmp_ex(data, "DILITHIUM-BRAINPOOL", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM3-BRAINPOOL", 0, 1) == 0 ||
-				str_cmp_ex(data, "D3-B256", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM3-B256", 0, 1) == 0) {
-		ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM3_BRAINPOOL256;
-	} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_ED25519_OID, 0, 1) == 0 || 
-				str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_ED25519_NAME, 0, 1) == 0 || 
-				str_cmp_ex(data, "DILITHIUM-ED25519", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM-25519", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM3-ED25519", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM3-25519", 0, 1) == 0 ||
-				str_cmp_ex(data, "D3-ED25519", 0, 1) == 0 ||
-				str_cmp_ex(data, "D3-25519", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM3-25519", 0, 1) == 0) {
-		ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM3_ED25519;
-	} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_P384_SHA384_OID, 0, 1) == 0 || 
-				str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_P384_SHA384_NAME, 0, 1) == 0 || 
-				str_cmp_ex(data, "DILITHIUM5-ECDSA", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM5-EC", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM-P384", 0, 1) == 0 ||
-				str_cmp_ex(data, "D5-P384", 0, 1) == 0 ||
-				str_cmp_ex(data, "D5-ECDSA", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM5-P384", 0, 1) == 0) {
-		ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM5_P384;
-	} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_BRAINPOOL384_SHA384_OID, 0, 1) == 0 || 
-				str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_BRAINPOOL384_SHA384_NAME, 0, 1) == 0 || 
-				str_cmp_ex(data, "DILITHIUM5-BRAINPOOL", 0, 1) == 0 ||
-				str_cmp_ex(data, "D5-B384", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM5-B384", 0, 1) == 0) {
-		ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM5_BRAINPOOL384;
-	} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_ED448_OID, 0, 1) == 0 || 
-				str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_ED448_NAME, 0, 1) == 0 || 
-				str_cmp_ex(data, "DILITHIUM5-448", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM-ED448", 0, 1) == 0 ||
-				str_cmp_ex(data, "D5-ED448", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM-448", 0, 1) == 0) {
-		ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM5_ED448;
-	} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_P256_SHA256_OID, 0, 1) == 0 || 
-				str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_P256_SHA256_NAME, 0, 1) == 0 || 
-				str_cmp_ex(data, "FALCON512-P256", 0, 1) == 0 || 
-				str_cmp_ex(data, "FALCON-ECDSA", 0, 1) == 0 || 
-				str_cmp_ex(data, "F512-ECDSA", 0, 1) == 0 || 
-				str_cmp_ex(data, "F512-P256", 0, 1) == 0 || 
-				str_cmp_ex(data, "FALCON-P256", 0, 1) == 0) {
-		ret = PKI_SCHEME_COMPOSITE_EXPLICIT_FALCON512_P256;
-	} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_BRAINPOOL256_SHA256_OID, 0, 1) == 0 || 
-				str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_BRAINPOOL256_SHA256_NAME, 0, 1) == 0 || 
-				str_cmp_ex(data, "FALCON512-BRAINPOOL", 0, 1) == 0 || 
-				str_cmp_ex(data, "FALCON-BRAINPOOL256", 0, 1) == 0 || 
-				str_cmp_ex(data, "F512-B256", 0, 1) == 0 || 
-				str_cmp_ex(data, "FALCON-BRAINPOOL", 0, 1) == 0) {
-		ret = PKI_SCHEME_COMPOSITE_EXPLICIT_FALCON512_BRAINPOOL256;
-	} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_ED25519_OID, 0, 1) == 0 ||
-				str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_ED25519_NAME, 0, 1) == 0 || 
-				str_cmp_ex(data, "FALCON512-25519", 0, 1) == 0 || 
-				str_cmp_ex(data, "FALCON-ED25519", 0, 1) == 0 || 
-				str_cmp_ex(data, "F512-ED25519", 0, 1) == 0 || 
-				str_cmp_ex(data, "FALCON-25519", 0, 1) == 0) {
-		return PKI_SCHEME_COMPOSITE_EXPLICIT_FALCON512_ED25519;
-	// } else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_SPHINCS256_P256_SHA256_OID, 0, 1) == 0 || 
-	// 			str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_SPHINCS256_P256_SHA256_NAME, 0, 1) == 0 || 
-	// 			str_cmp_ex(data, "SPHINCS256-ECDSA", 0, 1) == 0 || 
-	// 			str_cmp_ex(data, "SPHINCS-ECDSA", 0, 1) == 0 || 
-	// 			str_cmp_ex(data, "SPHINCS-P256", 0, 1) == 0) {
-	// 	return PKI_SCHEME_COMPOSITE_EXPLICIT_FALCON512_ED25519;
-	} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_RSAPSS_SHA256_OID, 0, 1) == 0 || 
-				str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_RSAPSS_SHA256_NAME, 0, 1) == 0 || 
-				str_cmp_ex(data, "DILITHIUM3-RSAPSS", 0, 1) == 0 || 
-				str_cmp_ex(data, "D3-RSAPSS", 0, 1) == 0 || 
-				str_cmp_ex(data, "DILITHIUM-RSAPSS", 0, 1) == 0) {
-		ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM3_RSAPSS;
-	} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_RSA_SHA256_OID, 0, 1) == 0 || 
-				str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_RSA_SHA256_NAME, 0, 1) == 0 || 
-				str_cmp_ex(data, "FALCON-RSA", 0, 1) == 0 ||
-				str_cmp_ex(data, "F512-RSA", 0, 1) == 0 ||
-				str_cmp_ex(data, "FALCON512-RSA", 0, 1) == 0) {
-		ret = PKI_SCHEME_COMPOSITE_EXPLICIT_FALCON512_RSA;
-	// Explicit Composite - DILITHIUM5-FALCON1024-ECDSA-P521
-	} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_FALCON1024_P521_SHA512_OID, 0, 1) == 0 ||
-				str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_FALCON1024_P521_SHA512_NAME, 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM-FALCON-EC", 0, 1) == 0 ||
-				str_cmp_ex(data, "D5-F1024-P521", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM5-FALCON1024-P521", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM-FALCON-P521", 0, 1) == 0) {
-		ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM5_FALCON1024_P521;
-	// Explicit Composite - DILITHIUM5-FALCON1024-ECDSA-RSA
-	} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_FALCON1024_RSA_SHA256_OID, 0, 1) == 0 ||
-				str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_FALCON1024_RSA_SHA256_NAME, 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM-FALCON-RSA", 0, 1) == 0 ||
-				str_cmp_ex(data, "D5-F1024-RSA", 0, 1) == 0 ||
-				str_cmp_ex(data, "DILITHIUM5-FALCON1024-RSA", 0, 1) == 0) {
-		ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM5_FALCON1024_RSA;
-	} else if (str_cmp_ex(data, "DILITHIUMX3", 0, 1) == 0) { 
-		ret = PKI_SCHEME_DILITHIUMX3;
-	} else if (str_cmp_ex(data, "DILITHIUM2", 0, 1) == 0) {
-		default_sec_bits = 0;
-		if (classic_sec_bits) *classic_sec_bits = 128;
-		if (quantum_sec_bits) *quantum_sec_bits = 128;
-		ret = PKI_SCHEME_DILITHIUM;
-	} else if (str_cmp_ex(data, "DILITHIUM3", 0, 1) == 0) {
-		default_sec_bits = 0;
-		if (classic_sec_bits) *classic_sec_bits = 192;
-		if (quantum_sec_bits) *quantum_sec_bits = 192;
-		ret = PKI_SCHEME_DILITHIUM;
-	} else if (str_cmp_ex(data, "DILITHIUM5", 0, 1) == 0) {
-		default_sec_bits = 0;
-		if (classic_sec_bits) *classic_sec_bits = 256;
-		if (quantum_sec_bits) *quantum_sec_bits = 256;
-		ret = PKI_SCHEME_DILITHIUM;
-	} else if (str_cmp_ex(data, "DILITHIUM", 0, 1) == 0) {
-		ret = PKI_SCHEME_DILITHIUM;
-	} else if (str_cmp_ex(data, "FALCON512", 0, 1) == 0) {
-		default_sec_bits = 0;
-		if (classic_sec_bits) *classic_sec_bits = 128;
-		if (quantum_sec_bits) *quantum_sec_bits = 128;
-		ret = PKI_SCHEME_FALCON;
-	} else if (str_cmp_ex(data, "FALCON1024", 0, 1) == 0) {
-		default_sec_bits = 0;
-		if (classic_sec_bits) *classic_sec_bits = 256;
-		if (quantum_sec_bits) *quantum_sec_bits = 256;
-		ret = PKI_SCHEME_FALCON;
-	} else if (str_cmp_ex(data, "FALCON", 0, 1) == 0) {
-		ret = PKI_SCHEME_FALCON;
-	} else if (str_cmp_ex(data, "COMPOSITE", 0, 1) == 0) {
-		ret = PKI_SCHEME_COMPOSITE;
-	} else if (str_cmp_ex(data, "KYBER", 0, 1) == 0) {
-		ret = PKI_SCHEME_KYBER;
+	// Generic Composite
+	if (ret == PKI_SCHEME_UNKNOWN) {
+		if (str_cmp_ex(data, "COMPOSITE", 0, 1) == 0) {
+			ret = PKI_SCHEME_COMPOSITE;
+		}
 	}
 
+#ifdef ENABLE_OQS
+
+	// Explicit Composite
+	if (ret == PKI_SCHEME_UNKNOWN) {
+		// Explicit Composite - DILITHIUM3-P256
+		if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_P256_SHA256_OID, 0, 1) == 0 ||
+			str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_P256_SHA256_NAME, 0, 1) == 0 ||
+			str_cmp_ex(data, "DILITHIUM3-ECDSA", 0, 1) == 0 ||
+			str_cmp_ex(data, "DILITHIUM3-EC", 0, 1) == 0 ||
+			str_cmp_ex(data, "DILITHIUM3-P256", 0, 1) == 0 ||
+			str_cmp_ex(data, "D3-P256", 0, 1) == 0 ||
+			str_cmp_ex(data, "DILITHIUM-P256", 0, 1) == 0) {
+			ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM3_P256;
+		// Explicit Composite - DILITHIUM3-RSA
+		} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_RSA_SHA256_OID, 0, 1) == 0 ||
+					str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_RSA_SHA256_NAME, 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM-RSA", 0, 1) == 0 ||
+					str_cmp_ex(data, "D3-RSA", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM3-RSA", 0, 1) == 0) {
+			ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM3_RSA;
+		// Explicit Composite - DILITHIUM3-BRAINPOOL256
+		} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_BRAINPOOL256_SHA256_OID, 0, 1) == 0 || 
+					str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_BRAINPOOL256_SHA256_NAME, 0, 1) == 0 || 
+					str_cmp_ex(data, "DILITHIUM-BRAINPOOL", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM3-BRAINPOOL", 0, 1) == 0 ||
+					str_cmp_ex(data, "D3-B256", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM3-B256", 0, 1) == 0) {
+			ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM3_BRAINPOOL256;
+		} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_ED25519_OID, 0, 1) == 0 || 
+					str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_ED25519_NAME, 0, 1) == 0 || 
+					str_cmp_ex(data, "DILITHIUM-ED25519", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM-25519", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM3-ED25519", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM3-25519", 0, 1) == 0 ||
+					str_cmp_ex(data, "D3-ED25519", 0, 1) == 0 ||
+					str_cmp_ex(data, "D3-25519", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM3-25519", 0, 1) == 0) {
+			ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM3_ED25519;
+		} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_P384_SHA384_OID, 0, 1) == 0 || 
+					str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_P384_SHA384_NAME, 0, 1) == 0 || 
+					str_cmp_ex(data, "DILITHIUM5-ECDSA", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM5-EC", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM-P384", 0, 1) == 0 ||
+					str_cmp_ex(data, "D5-P384", 0, 1) == 0 ||
+					str_cmp_ex(data, "D5-ECDSA", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM5-P384", 0, 1) == 0) {
+			ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM5_P384;
+		} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_BRAINPOOL384_SHA384_OID, 0, 1) == 0 || 
+					str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_BRAINPOOL384_SHA384_NAME, 0, 1) == 0 || 
+					str_cmp_ex(data, "DILITHIUM5-BRAINPOOL", 0, 1) == 0 ||
+					str_cmp_ex(data, "D5-B384", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM5-B384", 0, 1) == 0) {
+			ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM5_BRAINPOOL384;
+		} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_ED448_OID, 0, 1) == 0 || 
+					str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_ED448_NAME, 0, 1) == 0 || 
+					str_cmp_ex(data, "DILITHIUM5-448", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM-ED448", 0, 1) == 0 ||
+					str_cmp_ex(data, "D5-ED448", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM-448", 0, 1) == 0) {
+			ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM5_ED448;
+		} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_P256_SHA256_OID, 0, 1) == 0 || 
+					str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_P256_SHA256_NAME, 0, 1) == 0 || 
+					str_cmp_ex(data, "FALCON512-P256", 0, 1) == 0 || 
+					str_cmp_ex(data, "FALCON-ECDSA", 0, 1) == 0 || 
+					str_cmp_ex(data, "F512-ECDSA", 0, 1) == 0 || 
+					str_cmp_ex(data, "F512-P256", 0, 1) == 0 || 
+					str_cmp_ex(data, "FALCON-P256", 0, 1) == 0) {
+			ret = PKI_SCHEME_COMPOSITE_EXPLICIT_FALCON512_P256;
+		} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_BRAINPOOL256_SHA256_OID, 0, 1) == 0 || 
+					str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_BRAINPOOL256_SHA256_NAME, 0, 1) == 0 || 
+					str_cmp_ex(data, "FALCON512-BRAINPOOL", 0, 1) == 0 || 
+					str_cmp_ex(data, "FALCON-BRAINPOOL256", 0, 1) == 0 || 
+					str_cmp_ex(data, "F512-B256", 0, 1) == 0 || 
+					str_cmp_ex(data, "FALCON-BRAINPOOL", 0, 1) == 0) {
+			ret = PKI_SCHEME_COMPOSITE_EXPLICIT_FALCON512_BRAINPOOL256;
+		} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_ED25519_OID, 0, 1) == 0 ||
+					str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_ED25519_NAME, 0, 1) == 0 || 
+					str_cmp_ex(data, "FALCON512-25519", 0, 1) == 0 || 
+					str_cmp_ex(data, "FALCON-ED25519", 0, 1) == 0 || 
+					str_cmp_ex(data, "F512-ED25519", 0, 1) == 0 || 
+					str_cmp_ex(data, "FALCON-25519", 0, 1) == 0) {
+			return PKI_SCHEME_COMPOSITE_EXPLICIT_FALCON512_ED25519;
+		// } else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_SPHINCS256_P256_SHA256_OID, 0, 1) == 0 || 
+		// 			str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_SPHINCS256_P256_SHA256_NAME, 0, 1) == 0 || 
+		// 			str_cmp_ex(data, "SPHINCS256-ECDSA", 0, 1) == 0 || 
+		// 			str_cmp_ex(data, "SPHINCS-ECDSA", 0, 1) == 0 || 
+		// 			str_cmp_ex(data, "SPHINCS-P256", 0, 1) == 0) {
+		// 	return PKI_SCHEME_COMPOSITE_EXPLICIT_FALCON512_ED25519;
+		} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_RSAPSS_SHA256_OID, 0, 1) == 0 || 
+					str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_RSAPSS_SHA256_NAME, 0, 1) == 0 || 
+					str_cmp_ex(data, "DILITHIUM3-RSAPSS", 0, 1) == 0 || 
+					str_cmp_ex(data, "D3-RSAPSS", 0, 1) == 0 || 
+					str_cmp_ex(data, "DILITHIUM-RSAPSS", 0, 1) == 0) {
+			ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM3_RSAPSS;
+		} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_RSA_SHA256_OID, 0, 1) == 0 || 
+					str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_FALCON512_RSA_SHA256_NAME, 0, 1) == 0 || 
+					str_cmp_ex(data, "FALCON-RSA", 0, 1) == 0 ||
+					str_cmp_ex(data, "F512-RSA", 0, 1) == 0 ||
+					str_cmp_ex(data, "FALCON512-RSA", 0, 1) == 0) {
+			ret = PKI_SCHEME_COMPOSITE_EXPLICIT_FALCON512_RSA;
+		// Explicit Composite - DILITHIUM5-FALCON1024-ECDSA-P521
+		} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_FALCON1024_P521_SHA512_OID, 0, 1) == 0 ||
+					str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_FALCON1024_P521_SHA512_NAME, 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM-FALCON-EC", 0, 1) == 0 ||
+					str_cmp_ex(data, "D5-F1024-P521", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM5-FALCON1024-P521", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM-FALCON-P521", 0, 1) == 0) {
+			ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM5_FALCON1024_P521;
+		// Explicit Composite - DILITHIUM5-FALCON1024-ECDSA-RSA
+		} else if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_FALCON1024_RSA_SHA256_OID, 0, 1) == 0 ||
+					str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM5_FALCON1024_RSA_SHA256_NAME, 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM-FALCON-RSA", 0, 1) == 0 ||
+					str_cmp_ex(data, "D5-F1024-RSA", 0, 1) == 0 ||
+					str_cmp_ex(data, "DILITHIUM5-FALCON1024-RSA", 0, 1) == 0) {
+			ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM5_FALCON1024_RSA;
+		}
+	}
+#endif // End of ENABLE_OQS
+
+#endif // End of ENABLE_COMPOSITE
+
+#ifdef ENABLE_OQS
+	if (ret == PKI_SCHEME_UNKNOWN) {
+		if (str_cmp_ex(data, "DILITHIUMX3", 0, 1) == 0) { 
+			ret = PKI_SCHEME_DILITHIUMX3;
+		} else if (str_cmp_ex(data, "DILITHIUM2", 0, 1) == 0) {
+			default_sec_bits = 0;
+			if (classic_sec_bits) *classic_sec_bits = 128;
+			if (quantum_sec_bits) *quantum_sec_bits = 128;
+			ret = PKI_SCHEME_DILITHIUM;
+		} else if (str_cmp_ex(data, "DILITHIUM3", 0, 1) == 0) {
+			default_sec_bits = 0;
+			if (classic_sec_bits) *classic_sec_bits = 192;
+			if (quantum_sec_bits) *quantum_sec_bits = 192;
+			ret = PKI_SCHEME_DILITHIUM;
+		} else if (str_cmp_ex(data, "DILITHIUM5", 0, 1) == 0) {
+			default_sec_bits = 0;
+			if (classic_sec_bits) *classic_sec_bits = 256;
+			if (quantum_sec_bits) *quantum_sec_bits = 256;
+			ret = PKI_SCHEME_DILITHIUM;
+		} else if (str_cmp_ex(data, "DILITHIUM", 0, 1) == 0) {
+			ret = PKI_SCHEME_DILITHIUM;
+		} else if (str_cmp_ex(data, "FALCON512", 0, 1) == 0) {
+			default_sec_bits = 0;
+			if (classic_sec_bits) *classic_sec_bits = 128;
+			if (quantum_sec_bits) *quantum_sec_bits = 128;
+			ret = PKI_SCHEME_FALCON;
+		} else if (str_cmp_ex(data, "FALCON1024", 0, 1) == 0) {
+			default_sec_bits = 0;
+			if (classic_sec_bits) *classic_sec_bits = 256;
+			if (quantum_sec_bits) *quantum_sec_bits = 256;
+			ret = PKI_SCHEME_FALCON;
+		} else if (str_cmp_ex(data, "FALCON", 0, 1) == 0) {
+			ret = PKI_SCHEME_FALCON;
+		} else if (str_cmp_ex(data, "KYBER", 0, 1) == 0) {
+			ret = PKI_SCHEME_KYBER;
+		}
+	}
 #endif
 
 	// Checks for Traditional Crypto
@@ -1351,6 +1368,8 @@ PKI_SCHEME_ID PKI_SCHEME_ID_get_by_name(const char * data, int *classic_sec_bits
 		} else if (str_cmp_ex(data, "RSAPSS", 0, 1) == 0 ||
 				str_cmp_ex(data, "RSA-PSS", 0, 1) == 0) {
 			ret = PKI_SCHEME_RSAPSS;
+
+#ifdef ENABLE_ECDSA
 		// ED 25519 Option
 		} else if (str_cmp_ex(data, "ED25519", 0, 1) == 0) {
 			ret = PKI_SCHEME_ED25519;
@@ -1374,6 +1393,8 @@ PKI_SCHEME_ID PKI_SCHEME_ID_get_by_name(const char * data, int *classic_sec_bits
 				str_cmp_ex(data, "P384", 0, 1) == 0 ||
 				str_cmp_ex(data, "P512", 0, 1) == 0) {
 			ret = PKI_SCHEME_ECDSA;
+#endif // End of ENABLE_ECDSA
+
 		// DSA
 		} else if (str_cmp_ex(data, "DSA", 0, 1) == 0) {
 			ret = PKI_SCHEME_DSA;

--- a/src/openssl/pki_algor.c
+++ b/src/openssl/pki_algor.c
@@ -434,6 +434,8 @@ int PKI_SCHEME_ID_is_post_quantum(PKI_SCHEME_ID id) {
 
 	switch (id) {
 
+#ifdef ENABLE_OQS
+
 		// Signature
 	#ifdef OQS_ENABLE_SIG_DILITHIUM
 		case PKI_SCHEME_DILITHIUM:
@@ -465,6 +467,8 @@ int PKI_SCHEME_ID_is_post_quantum(PKI_SCHEME_ID id) {
 		case PKI_SCHEME_DILITHIUMX3: {
 			// Nothing to do
 		} break;
+
+#endif // End of ENABLE_OQS
 
 		default:
 			// Non-Post Quantum
@@ -1184,6 +1188,8 @@ PKI_SCHEME_ID PKI_SCHEME_ID_get_by_name(const char * data, int *classic_sec_bits
 		return PKI_SCHEME_UNKNOWN;
 	}
 
+#ifdef ENABLE_OQS
+
 	// Explicit Composite - DILITHIUM3-P256
 	if (str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_P256_SHA256_OID, 0, 1) == 0 ||
 		str_cmp_ex(data, OPENCA_ALG_PKEY_EXP_COMP_EXPLICIT_DILITHIUM3_P256_SHA256_NAME, 0, 1) == 0 ||
@@ -1295,39 +1301,6 @@ PKI_SCHEME_ID PKI_SCHEME_ID_get_by_name(const char * data, int *classic_sec_bits
 				str_cmp_ex(data, "D5-F1024-RSA", 0, 1) == 0 ||
 				str_cmp_ex(data, "DILITHIUM5-FALCON1024-RSA", 0, 1) == 0) {
 		ret = PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM5_FALCON1024_RSA;
-	// RSA Option
-	} else if (str_cmp_ex(data, "RSA", 0, 1) == 0) {
-		ret = PKI_SCHEME_RSA;
-	// RSA-PSS Option
-	} else if (str_cmp_ex(data, "RSAPSS", 0, 1) == 0 ||
-			   str_cmp_ex(data, "RSA-PSS", 0, 1) == 0) {
-		ret = PKI_SCHEME_RSAPSS;
-	// ED 25519 Option
-	} else if (str_cmp_ex(data, "ED25519", 0, 1) == 0) {
-		ret = PKI_SCHEME_ED25519;
-	// X25519 Option
-	} else if (str_cmp_ex(data, "X25519", 0, 1) == 0) {
-		ret = PKI_SCHEME_X25519;
-	// ED 448 Option
-	} else if (str_cmp_ex(data, "ED448", 0, 1) == 0) {
-		ret = PKI_SCHEME_ED448;
-	// X448 Option
-	} else if (str_cmp_ex(data, "X448", 0, 1) == 0) {
-		ret = PKI_SCHEME_X448;
-	// EC Option
-	} else if (str_cmp_ex(data, "EC", 0, 1) == 0 ||
-			   str_cmp_ex(data, "ECDSA", 0, 1) == 0 ||
-			   str_cmp_ex(data, "B128", 0, 1) == 0 ||
-			   str_cmp_ex(data, "B192", 0, 1) == 0 ||
-			   str_cmp_ex(data, "B256", 0, 1) == 0 ||
-			   str_cmp_ex(data, "Brainpool", 9, 1) == 0 ||
-			   str_cmp_ex(data, "P256", 0, 1) == 0 ||
-			   str_cmp_ex(data, "P384", 0, 1) == 0 ||
-			   str_cmp_ex(data, "P512", 0, 1) == 0) {
-		ret = PKI_SCHEME_ECDSA;
-	// DSA
-	} else if (str_cmp_ex(data, "DSA", 0, 1) == 0) {
-		ret = PKI_SCHEME_DSA;
 	} else if (str_cmp_ex(data, "DILITHIUMX3", 0, 1) == 0) { 
 		ret = PKI_SCHEME_DILITHIUMX3;
 	} else if (str_cmp_ex(data, "DILITHIUM2", 0, 1) == 0) {
@@ -1365,17 +1338,60 @@ PKI_SCHEME_ID PKI_SCHEME_ID_get_by_name(const char * data, int *classic_sec_bits
 		ret = PKI_SCHEME_KYBER;
 	}
 
-	if (!ret) {
-		// Some debugging
-		PKI_DEBUG("Cannot Convert [%s] into a recognized OID.", data);
+#endif
+
+	// Checks for Traditional Crypto
+	// =============================
+	
+	if (ret == PKI_SCHEME_UNKNOWN) {
+		// RSA Option
+		if (str_cmp_ex(data, "RSA", 0, 1) == 0) {
+			ret = PKI_SCHEME_RSA;
+		// RSA-PSS Option
+		} else if (str_cmp_ex(data, "RSAPSS", 0, 1) == 0 ||
+				str_cmp_ex(data, "RSA-PSS", 0, 1) == 0) {
+			ret = PKI_SCHEME_RSAPSS;
+		// ED 25519 Option
+		} else if (str_cmp_ex(data, "ED25519", 0, 1) == 0) {
+			ret = PKI_SCHEME_ED25519;
+		// X25519 Option
+		} else if (str_cmp_ex(data, "X25519", 0, 1) == 0) {
+			ret = PKI_SCHEME_X25519;
+		// ED 448 Option
+		} else if (str_cmp_ex(data, "ED448", 0, 1) == 0) {
+			ret = PKI_SCHEME_ED448;
+		// X448 Option
+		} else if (str_cmp_ex(data, "X448", 0, 1) == 0) {
+			ret = PKI_SCHEME_X448;
+		// EC Option
+		} else if (str_cmp_ex(data, "EC", 0, 1) == 0 ||
+				str_cmp_ex(data, "ECDSA", 0, 1) == 0 ||
+				str_cmp_ex(data, "B128", 0, 1) == 0 ||
+				str_cmp_ex(data, "B192", 0, 1) == 0 ||
+				str_cmp_ex(data, "B256", 0, 1) == 0 ||
+				str_cmp_ex(data, "Brainpool", 9, 1) == 0 ||
+				str_cmp_ex(data, "P256", 0, 1) == 0 ||
+				str_cmp_ex(data, "P384", 0, 1) == 0 ||
+				str_cmp_ex(data, "P512", 0, 1) == 0) {
+			ret = PKI_SCHEME_ECDSA;
+		// DSA
+		} else if (str_cmp_ex(data, "DSA", 0, 1) == 0) {
+			ret = PKI_SCHEME_DSA;
+		}
 	}
 
-	// Checks if we need to retrieve the default security bits
-	if (default_sec_bits) {
-		// Returns the security bits for the scheme
-		if (PKI_ERR == PKI_SCHEME_ID_security_bits(ret, classic_sec_bits, quantum_sec_bits)) {
-			PKI_DEBUG("Cannot get security bits for scheme %d", ret);
-			return PKI_SCHEME_UNKNOWN;
+	// Checks if we found the scheme
+	if (ret == PKI_SCHEME_UNKNOWN) {
+		// Some debugging
+		PKI_DEBUG("Cannot Convert [%s] into a recognized OID.", data);
+	} else {
+		// Checks if we need to retrieve the default security bits
+		if (default_sec_bits) {
+			// Returns the security bits for the scheme
+			if (PKI_ERR == PKI_SCHEME_ID_security_bits(ret, classic_sec_bits, quantum_sec_bits)) {
+				PKI_DEBUG("Cannot get security bits for scheme %d", ret);
+				return PKI_SCHEME_UNKNOWN;
+			}
 		}
 	}
 

--- a/src/openssl/pki_id.c
+++ b/src/openssl/pki_id.c
@@ -195,6 +195,8 @@ int PKI_ID_is_pqc(PKI_ID id, PKI_SCHEME_ID * scheme_id) {
 	// Checks the PKEY / Signatures
 	switch (id) {
 
+#ifdef ENABLE_PQC
+
 		// Signature Algorithms
 		case NID_dilithium2:
         case NID_dilithium3:
@@ -259,6 +261,8 @@ int PKI_ID_is_pqc(PKI_ID id, PKI_SCHEME_ID * scheme_id) {
 			if (scheme_id) *scheme_id = PKI_SCHEME_CLASSIC_MCELIECE;
 			return PKI_OK;
 		} break;
+
+#endif // End of ENABLE_PQC
 
 		default:
 			break;

--- a/src/openssl/pki_keypair.c
+++ b/src/openssl/pki_keypair.c
@@ -926,7 +926,7 @@ int PKI_X509_KEYPAIR_get_curve(const PKI_X509_KEYPAIR *kp) {
 	}
 
 	// Retrieves the EC key
-	EC_KEY * ec = EVP_PKEY_get0_EC_KEY((EVP_PKEY *)kp->value);
+	EC_KEY * ec = (EC_KEY *)EVP_PKEY_get0_EC_KEY((EVP_PKEY *)kp->value);
 	if (!ec) {
 		PKI_ERROR(PKI_ERR_POINTER_NULL, NULL);
 		return PKI_ERR;

--- a/src/openssl/pki_keyparams.c
+++ b/src/openssl/pki_keyparams.c
@@ -435,6 +435,14 @@ int PKI_KEYPARAMS_set_scheme(PKI_KEYPARAMS * kp, PKI_SCHEME_ID scheme_id, int se
 			}
 			kp->pkey_type = kp->oqs.algId;
 		} break;
+#endif
+
+#ifdef ENABLE_COMBINED
+		case PKI_SCHEME_COMBINED: {
+			// No need to translate, output the input
+			ret = sec_bits;
+		} break;
+#endif
 
 #ifdef ENABLE_COMPOSITE
 
@@ -447,15 +455,8 @@ int PKI_KEYPARAMS_set_scheme(PKI_KEYPARAMS * kp, PKI_SCHEME_ID scheme_id, int se
 			kp->pkey_type = PKI_ID_get_by_name(OPENCA_ALG_PKEY_EXP_COMP_NAME);
 			kp->sec_bits = sec_bits;
 		} break;
-#endif
 
-#ifdef ENABLE_COMBINED
-		case PKI_SCHEME_COMBINED: {
-			// No need to translate, output the input
-			ret = sec_bits;
-		} break;
-#endif
-
+#ifdef ENABLE_OQS
 		// ===============================
 		// Explicit Composite Combinations
 		// ===============================
@@ -573,7 +574,9 @@ int PKI_KEYPARAMS_set_scheme(PKI_KEYPARAMS * kp, PKI_SCHEME_ID scheme_id, int se
 			kp->pq_sec_bits = 256;
 		} break;
 
-#endif // ENABLE_OQS
+#endif // End of ENABLE_OQS
+
+#endif // End of ENABLE_COMPOSITE
 
 		default: {
 			// Sets the sec_bits

--- a/src/openssl/pki_keyparams.c
+++ b/src/openssl/pki_keyparams.c
@@ -790,6 +790,8 @@ int PKI_KEYPARAMS_set_oqs_key_params(PKI_KEYPARAMS * kp, PKI_ALGOR_OQS_PARAM alg
 /*! \brief Sets the bits size for key generation */
 int PKI_KEYPARAMS_add_key(PKI_KEYPARAMS * kp, PKI_X509_KEYPAIR * key) {
 
+#ifdef ENABLE_COMPOSITE
+
 	int add_key_id = -1;
 	int last_key_id = -1;
 	int next_required_id = -1;
@@ -839,6 +841,8 @@ int PKI_KEYPARAMS_add_key(PKI_KEYPARAMS * kp, PKI_X509_KEYPAIR * key) {
 		case PKI_SCHEME_COMPOSITE: {
 			next_required_id = 0; // No Required ID (any can work)
 		} break;
+
+#ifdef ENABLE_OQS
 
 		case PKI_SCHEME_COMPOSITE_EXPLICIT_DILITHIUM3_RSA: {
 
@@ -1064,6 +1068,8 @@ int PKI_KEYPARAMS_add_key(PKI_KEYPARAMS * kp, PKI_X509_KEYPAIR * key) {
 				return PKI_ERR;
 			}
 		} break;
+		
+#endif // End of ENABLE_OQS
 
 		default: {
 			// Not Handled
@@ -1088,6 +1094,14 @@ int PKI_KEYPARAMS_add_key(PKI_KEYPARAMS * kp, PKI_X509_KEYPAIR * key) {
 
 	// All Done
 	return PKI_OK;
+
+#else
+
+	// No Composite Support
+	return PKI_ERR;
+
+#endif // End of ENABLE_COMPOSITE
+
 }
 
 /*! \brief Sets the k_of_n parameter for Composite keys */

--- a/src/openssl/pqc/pqc_asn1_meth.c
+++ b/src/openssl/pqc/pqc_asn1_meth.c
@@ -1,8 +1,7 @@
 
-
-#ifndef _LIBPKI_PQC_AMETH_LOCAL_H
 #include "pqc_asn1_meth.h"
-#endif
+
+#ifdef ENABLE_OQS
 
 // ===========
 // AMETH Tools
@@ -514,3 +513,5 @@ int oqs_ameth_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2) {
 // DEFINE_OQS_EVP_METHODS(sphincssha256128frobust, NID_sphincssha256128frobust, "sphincssha256128frobust", "OpenSSL SPHINCS+-SHA256-128f-robust algorithm")
 // DEFINE_OQS_EVP_METHODS(sphincsshake256128frobust, NID_sphincsshake256128frobust, "sphincsshake256128frobust", "OpenSSL SPHINCS+-SHAKE256-128f-robust algorithm")
 // ///// OQS_TEMPLATE_FRAGMENT_DEFINE_OQS_EVP_METHS_END
+
+#endif // End of ENABLE_OQS

--- a/src/openssl/pqc/pqc_asn1_meth.h
+++ b/src/openssl/pqc/pqc_asn1_meth.h
@@ -2,6 +2,11 @@
 #ifndef _LIBPKI_PQC_AMETH_LOCAL_H
 #define _LIBPKI_PQC_AMETH_LOCAL_H
 
+// Include the library configuration
+#include <libpki/config.h>
+
+#ifdef ENABLE_OQS
+
 #ifndef _LIBPKI_OS_H
 #include <libpki/os.h>
 #endif
@@ -20,6 +25,10 @@
 
 #ifndef _LIBPKI_PQC_TOOLS_H
 #include "pqc_tools.h"
+#endif
+
+#ifndef HEADER_OPENSSL_TYPES_H
+#include <openssl/ossl_typ.h>
 #endif
 
 #ifndef HEADER_ERR_H
@@ -127,4 +136,6 @@ int oqs_ameth_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2);
 
 END_C_DECLS
 
-# endif // End of _LIBPKI_PQC_AMETH_LOCAL_H
+# endif // End of ENABLE_OQS
+
+#endif // End of _LIBPKI_PQC_AMETH_LOCAL_H

--- a/src/openssl/pqc/pqc_data_st.h
+++ b/src/openssl/pqc/pqc_data_st.h
@@ -1,16 +1,21 @@
 #ifndef _LIBPKI_PQC_LOCAL_H
 #define _LIBPKI_PQC_LOCAL_H
 
-#include <libpki/os.h>
-#include <libpki/compat.h>
+// Include the library configuration
+#include <libpki/config.h>
 
-#ifndef OQS_H
-#include <oqs/oqs.h>
-#endif
+# ifdef ENABLE_OQS
 
-#ifndef LIBPKI_X509_DATA_ST_H
-#include "../internal/x509_data_st.h"
-#endif
+#  include <libpki/os.h>
+#  include <libpki/compat.h>
+
+#  ifndef OQS_H
+#   include <oqs/oqs.h>
+#  endif
+
+#  ifndef LIBPKI_X509_DATA_ST_H
+#   include "../internal/x509_data_st.h"
+#  endif
 
 BEGIN_C_DECLS
 
@@ -45,4 +50,6 @@ typedef enum {
 
 END_C_DECLS
 
-# endif // End of _LIBPKI_PQC_LOCAL_H
+# endif // End of ENABLE_OQS
+
+#endif // End of _LIBPKI_PQC_LOCAL_H

--- a/src/openssl/pqc/pqc_init.c
+++ b/src/openssl/pqc/pqc_init.c
@@ -1,4 +1,9 @@
 
+// Include the library configuration
+#include <libpki/config.h>
+
+#ifdef ENABLE_OQS
+
 #ifndef _LIBPKI_LOG_H
 #include <libpki/pki_log.h>
 #endif
@@ -248,7 +253,7 @@ EVP_PKEY_ASN1_METHOD * PKI_PQC_PKEY_ASN1_METH_new(int                nid,
 
   // All Done
   return a_meth;
-};
+}
 
 int PKI_PQC_ALG_new(const char * name, int flags) {
 
@@ -309,7 +314,7 @@ int PKI_PQC_ALG_new(const char * name, int flags) {
 
   // All Done
   return PKI_OK;
-};
+}
 
 int PKI_PQC_init() {
 
@@ -323,4 +328,6 @@ int PKI_PQC_init() {
 
   // All Done
   return PKI_OK;
-};
+}
+
+#endif // End of ENABLE_OQS

--- a/src/openssl/pqc/pqc_pkey_meth.c
+++ b/src/openssl/pqc/pqc_pkey_meth.c
@@ -1,8 +1,8 @@
 
 
-#ifndef _LIBPKI_PQC_AMETH_LOCAL_H
 #include "pqc_pkey_meth.h"
-#endif
+
+#ifdef ENABLE_OQS
 
 #ifndef _LIBPKI_LOG_H
 #include <libpki/pki_log.h>
@@ -451,3 +451,5 @@ int pkey_oqs_digestverify(EVP_MD_CTX *ctx, const unsigned char *sig,
 int pkey_oqs_digestcustom(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx) {
    return 1;
 }
+
+#endif // End of ENABLE_OQS

--- a/src/openssl/pqc/pqc_pkey_meth.h
+++ b/src/openssl/pqc/pqc_pkey_meth.h
@@ -2,6 +2,11 @@
 #ifndef _LIBPKI_PQC_PKEY_METH_LOCAL_H
 #define _LIBPKI_PQC_PKEY_METH_LOCAL_H
 
+// Include the library configuration
+#include <libpki/config.h>
+
+#ifdef ENABLE_OQS
+
 #ifndef _LIBPKI_OS_H
 #include <libpki/os.h>
 #endif
@@ -73,5 +78,7 @@ int pkey_oqs_digestcustom(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx);
 
 
 END_C_DECLS
+
+#endif // End of ENABLE_OQS
 
 #endif // End of _LIBPKI_PQC_PKEY_METH_LOCAL_H

--- a/src/openssl/pqc/pqc_tools.c
+++ b/src/openssl/pqc/pqc_tools.c
@@ -5,6 +5,8 @@
 // Functions
 // =========
 
+#ifdef ENABLE_OQS
+
 int oqssl_sig_nids_list[] = {
 ///// OQS_TEMPLATE_FRAGMENT_LIST_KNOWN_NIDS_START
         NID_dilithium2,
@@ -453,3 +455,5 @@ int oqs_int_update(EVP_MD_CTX *ctx, const void *data, size_t count)
     }
     return 1;
 }
+
+#endif // End of ENABLE_OQS

--- a/src/openssl/pqc/pqc_tools.h
+++ b/src/openssl/pqc/pqc_tools.h
@@ -2,6 +2,11 @@
 #ifndef _LIBPKI_PQC_TOOLS_H
 #define _LIBPKI_PQC_TOOLS_H
 
+// Include the library configuration
+#include <libpki/config.h>
+
+#ifdef ENABLE_OQS
+
 #ifndef _LIBPKI_OS_H
 #include <libpki/os.h>
 #endif
@@ -69,5 +74,7 @@ void oqs_pkey_ctx_free(OQS_KEY* key);
 int oqs_int_update(EVP_MD_CTX *ctx, const void *data, size_t count);
 
 END_C_DECLS
+
+#endif // End of ENABLE_OQS
 
 #endif // End of _LIBPKI_PQC_TOOLS_H

--- a/src/pki_x509.c
+++ b/src/pki_x509.c
@@ -41,67 +41,77 @@ const ASN1_ITEM * _get_ossl_item(PKI_DATATYPE type) {
 	switch (type) {
 
 		case PKI_DATATYPE_X509_CERT : {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-	        it = (ASN1_ITEM *) X509_CINF_it;
-#else
-			it = &X509_CINF_it;
-#endif
+			it = ASN1_ITEM_rptr(X509_CINF);
+// #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+// 	        it = (ASN1_ITEM *) X509_CINF_it;
+// #else
+// 			it = &X509_CINF_it;
+// #endif
 		} break;
 
 		case PKI_DATATYPE_X509_CRL : {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-			it = (ASN1_ITEM *) X509_CRL_INFO_it;
-#else
-			it = &X509_CRL_INFO_it;
-#endif
+			it = ASN1_ITEM_rptr(X509_CRL_INFO);
+
+// #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+// 			// it = (ASN1_ITEM *)X509_CRL_INFO_it;
+// #else
+// 			// it = &X509_CRL_INFO_it;
+// 			it = ASN1_ITEM_rptr(X509_CRL_INFO);
+// #endif
 		} break;
 
 		case PKI_DATATYPE_X509_REQ : {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-			it = (ASN1_ITEM *) X509_REQ_INFO_it;
-#else
-			it = &X509_REQ_INFO_it;
-#endif
+			it = ASN1_ITEM_rptr(X509_REQ_INFO);
+// #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+// 			it = (ASN1_ITEM *) X509_REQ_INFO_it;
+// #else
+// 			it = &X509_REQ_INFO_it;
+// #endif
 		} break;
 
 		case PKI_DATATYPE_X509_OCSP_REQ : {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-			it = (ASN1_ITEM *) OCSP_REQINFO_it;
-#else
-			it = &OCSP_REQINFO_it;
-#endif
+			it = ASN1_ITEM_rptr(OCSP_REQINFO);
+// #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+// 			it = (ASN1_ITEM *) OCSP_REQINFO_it;
+// #else
+// 			it = &OCSP_REQINFO_it;
+// #endif
 		} break;
 
 		case PKI_DATATYPE_X509_OCSP_RESP : {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-			it = (ASN1_ITEM *) OCSP_RESPDATA_it;
-#else
-			it = &OCSP_RESPDATA_it;
-#endif
+			it = ASN1_ITEM_rptr(OCSP_RESPDATA);
+// #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+// 			it = (ASN1_ITEM *) OCSP_RESPDATA_it;
+// #else
+// 			it = &OCSP_RESPDATA_it;
+// #endif
 		} break;
 
 		case PKI_DATATYPE_X509_PRQP_REQ : {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-			it = (ASN1_ITEM *) PKI_PRQP_REQ_it;
-#else
-			it = &PKI_PRQP_REQ_it;
-#endif
+			it = ASN1_ITEM_rptr(PKI_PRQP_REQ);
+// #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+// 			it = (ASN1_ITEM *) PKI_PRQP_REQ_it;
+// #else
+// 			it = &PKI_PRQP_REQ_it;
+// #endif
 		} break;
 
 		case PKI_DATATYPE_X509_PRQP_RESP : {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-			it = (ASN1_ITEM *) PKI_PRQP_RESP_it;
-#else
-			it = &PKI_PRQP_RESP_it;
-#endif
+			it = ASN1_ITEM_rptr(PKI_PRQP_RESP);
+// #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+// 			it = (ASN1_ITEM *) PKI_PRQP_RESP_it;
+// #else
+// 			it = &PKI_PRQP_RESP_it;
+// #endif
 		} break;
 
 		case PKI_DATATYPE_X509_CMS : {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-			it = (ASN1_ITEM *) CMS_ContentInfo_it;
-#else
-			it = &CMS_ContentInfo_it;
-#endif
+			it = ASN1_ITEM_rptr(CMS_ContentInfo);
+// #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+// 			it = (ASN1_ITEM *) CMS_ContentInfo_it;
+// #else
+// 			it = &CMS_ContentInfo_it;
+// #endif
 		}
 
 		case PKI_DATATYPE_X509_KEYPAIR: {
@@ -109,11 +119,12 @@ const ASN1_ITEM * _get_ossl_item(PKI_DATATYPE type) {
 		} break;
 
 		case PKI_DATATYPE_X509_EXTENSION: {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-			it = (ASN1_ITEM *) X509_EXTENSION_it;
-#else
-			it = &X509_EXTENSION_it;
-#endif
+			it = ASN1_ITEM_rptr(X509_EXTENSION);
+// #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+// 			it = (ASN1_ITEM *) X509_EXTENSION_it;
+// #else
+// 			it = &X509_EXTENSION_it;
+// #endif
 		} break;
 
 		default: {

--- a/src/tests/11_ameth_traditional_pqc_composite_explicit.c
+++ b/src/tests/11_ameth_traditional_pqc_composite_explicit.c
@@ -61,7 +61,7 @@ int subtest1() {
 	int idx = 0;
 	int arr[22] = { 0x0 };
 
-	printf("  - Subtest 1: ASN1 method find\n");
+	printf("   - Subtest 1: ASN1 method find\n");
 
 	// Populate the array with the algorithm IDs
 	arr[idx++] = PKI_ALGOR_ID_RSA;
@@ -78,6 +78,8 @@ int subtest1() {
 #ifdef ENABLE_COMPOSITE
 	// Generic Composite
 	arr[idx++] = PKI_ID_get_by_name("COMPOSITE");
+
+#ifdef ENABLE_OQS
 	// Explicit Composite
 	arr[idx++] = PKI_ID_get_by_name("DILITHIUM3-RSA-SHA256");
 	arr[idx++] = PKI_ID_get_by_name("DILITHIUM3-P256-SHA256");
@@ -94,21 +96,24 @@ int subtest1() {
 	arr[idx++] = PKI_ID_get_by_name("DILITHIUM5-FALCON1024-P512-SHA512");
 	arr[idx++] = PKI_ID_get_by_name("DILITHIUM5-FALCON1024-RSA-SHA256");
 #endif
+#endif
 
 	const EVP_PKEY_ASN1_METHOD *ameth_one;
 	// const EVP_PKEY_ASN1_METHOD *ameth_two;
 
-	for (int idx = 0; idx < 11; idx++) {
-		ameth_one = EVP_PKEY_asn1_find(NULL, arr[idx]);
+	for (int i = 0; i < idx; i++) {
+		printf("     + Method %s ...: ", PKI_ID_get_txt(arr[i]));
+		ameth_one = EVP_PKEY_asn1_find(NULL, arr[i]);
 		if (!ameth_one) {
 			printf("ERROR, can not find method for %s (%d)!\n",
-				PKI_ID_get_txt(arr[idx]), arr[idx]);
+				PKI_ID_get_txt(arr[i]), arr[i]);
 			exit(1);
 		}
+		printf("Ok\n");
 	}
 
 	// Info
-	printf("  - Subtest 1: Passed\n\n");
+	printf("   - Subtest 1: Passed\n\n");
 
 	// All Done
 	return 1;

--- a/src/tests/6_token_digest_crl_sign.c
+++ b/src/tests/6_token_digest_crl_sign.c
@@ -71,7 +71,6 @@ int subtest1() {
 	// PKI_OID *oid = NULL;
 
 	PKI_X509_CRL *crl = NULL;
-	PKI_X509_CRL_ENTRY *entry = NULL;
 	PKI_X509_CRL_ENTRY_STACK *sk = NULL;
 
 	if ((tk = PKI_TOKEN_new_null()) == NULL ) {
@@ -113,7 +112,16 @@ int subtest1() {
 	// 		return(0);
 	// }
 
+	PKI_DEBUG("Generating a new stack of entries");
+	sk = PKI_STACK_X509_CRL_ENTRY_new();
+	if (!sk) {
+		PKI_log_err("ERROR!\n");
+		return 0;
+	}
+	PKI_DEBUG("Stack of entries generated successfuly");
+
 	PKI_DEBUG("Generating a new CRL ENTRY");
+	PKI_X509_CRL_ENTRY *entry = NULL;
 	if((entry = PKI_X509_CRL_ENTRY_new_serial("12345678", 
 											  CRL_REASON_KEY_COMPROMISE,
 											  NULL,
@@ -123,11 +131,10 @@ int subtest1() {
 		return 0;
 	}
 	PKI_DEBUG("CRL ENTRY Generated Successfuly");
-
-	sk = PKI_STACK_X509_CRL_ENTRY_new();
 	PKI_STACK_X509_CRL_ENTRY_push( sk, entry );
 
 	PKI_DEBUG("Generating new CRL");
+
 	if((crl = PKI_TOKEN_issue_crl (tk, 
 								   "3", 
 								   0,
@@ -138,6 +145,7 @@ int subtest1() {
 		PKI_log_err("ERROR, can not generate new CRL!\n");
 		return 0;
 	}
+
 	PKI_DEBUG("CRL Generated Successfuly");
 
 	if( tk ) PKI_TOKEN_free ( tk );


### PR DESCRIPTION
Provides support for OpenSSL 3.1.x+ (closes #78) and few code fixes for ASN1_ITEM assigning in PKI_X509 structures. 