### PR TITLE
configure: uname -p -> uname -m to avoid getting unknown return

### DIFF
--- a/configure
+++ b/configure
@@ -2924,7 +2924,7 @@ mybits="32"
 mybits_install=""
 is_sparc="no"
 is_aix="no"
-my_arch=`uname -p`
+my_arch=`uname -m`
 
 case "$my_arch" in
   *i686)


### PR DESCRIPTION
On a Debian System for example, `uname -p` returns `unknown`. Whereas `uname -m` returns the correct machine type for example `x86_64`.

**Example:**
`root@debian:~# uname -p`
`unknown`
`root@debian:~# uname -m`
`x86_64`