### PR TITLE
Support libxml2 >= 2.12

### DIFF
--- a/src/pki_config.c
+++ b/src/pki_config.c
@@ -17,6 +17,7 @@ static char *def_conf_dirs[] = {
 
 #define PKI_DEF_CONF_DIRS_SIZE	2
 #define LIBXML_MIN_VERSION 20600
+#define LIBXML_212_VERSION 21200
 
 #if LIBXML_VERSION < LIBXML_MIN_VERSION
 #define xmlErrorPtr void *
@@ -30,7 +31,11 @@ static char *def_conf_dirs[] = {
 #endif
 */
 
+#if LIBXML_VERSION >= LIBXML_212_VERSION
+void logXmlMessages( void *userData, const xmlError *error ) {
+#else
 void logXmlMessages( void *userData, xmlErrorPtr error ) {
+#endif
 #if LIBXML_VERSION >= LIBXML_MIN_VERSION
 	PKI_log_err( "XML I/O Error: %s", error->message);
 #else


### PR DESCRIPTION
Small patch to cope with libxml2-2.12 breaking change (https://github.com/GNOME/libxml2/commit/61034116d0a3c8b295c6137956adc3ae55720711)
